### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ func loadTemplates(templatesDir string) multitemplate.Renderer {
 
 	// Generate our templates map from our layouts/ and includes/ directories
 	for _, include := range includes {
-		files := append(layouts, include)
+		layoutCopy := make([]string, len(layouts))
+		copy(layoutCopy, layouts)
+		files := append(layoutCopy, include)
 		r.AddFromFiles(filepath.Base(include), files...)
 	}
 	return r


### PR DESCRIPTION
Using `go version go1.11 windows/amd64` with the current example results in the render being returned in [dynamic:144](https://github.com/gin-contrib/multitemplate/blob/5799bbbb6dce3a499d45a53176f8ad72978d951d/dynamic.go#L144) will only have the _last_ layout being passed through the function. Copying the layouts beforehand fixes this.